### PR TITLE
k8sniff build automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 sniff
 .wercker
 vendor
+build
+.reviewboardrc

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
-
 SRC_DIR=$(shell pwd)
 BUILD_DIR=$(SRC_DIR)/build
 BIN_DIR=$(BUILD_DIR)/bin
-BUILD_SRC_DIR=$(BUILD_DIR)/src/github.com/kubermatic
-K8SNIFF_SRC_DIR=$(BUILD_SRC_DIR)/k8sniff
 K8SNIFF_EXE=$(BIN_DIR)/k8sniff
-GOSRC=$(GOPATH_DIR)/src
+GOSRC=$(GOPATH)/src
+K8SNIFF_SRC_DIR=$(GOSRC)/github.com/kubermatic/k8sniff
+DEP_SRC=$(GOSRC)/github.com/golang/dep
+DEP_EXE=$(DEP_SRC)/cmd/dep/dep
+VENDOR_DIR=$(K8SNIFF_SRC_DIR)/vendor
 
 GO_DEPS := \
-	$(GOSRC)/github.com/prometheus/client_golang \
-	$(GOSRC)/github.com/platform9/cnxmd \
-	$(GOSRC)/github.com/golang/glog
+	$(GOSRC)/github.com/golang/glog \
+	$(GOSRC)/github.com/prometheus/client_golang/prometheus \
+	$(GOSRC)/github.com/platform9/cnxmd/pkg/cnxmd
 
 $(GO_DEPS): $(GOPATH_DIR)
 	go get $(subst $(GOSRC)/,,$@)
@@ -19,15 +20,17 @@ $(GO_DEPS): $(GOPATH_DIR)
 K8SNIFF_IMAGE_TAG ?= platform9systems/k8sniff
 K8SNIFF_DEVEL_IMAGE_TAG ?= platform9systems/k8sniff-devel
 
-$(BUILD_SRC_DIR):
-	mkdir -p $@
+$(DEP_SRC):
+	go get -u github.com/golang/dep/cmd/dep
 
-$(K8SNIFF_SRC_DIR): | $(BUILD_SRC_DIR)
-	mkdir -p $@
-	cp -a $(SRC_DIR)/{cmd,pkg} $@/
+$(DEP_EXE): | $(DEP_SRC)
+	cd $(DEP_SRC)/cmd/dep && go build
 
 $(BIN_DIR):
 	mkdir -p $@
+
+$(VENDOR_DIR): $(DEP_EXE)
+	$(DEP_EXE) ensure
 
 local-k8sniff:
 	cd $(SRC_DIR)/cmd/k8sniff && go build -o $${GOPATH}/bin/k8sniff
@@ -35,13 +38,13 @@ local-k8sniff:
 local-k8sniff-dbg:
 	cd $(SRC_DIR)/cmd/k8sniff && go build -gcflags='-N -l' -o $${GOPATH}/bin/k8sniff-dbg
 
-$(K8SNIFF_EXE): | $(BIN_DIR) $(GO_DEPS)
+$(K8SNIFF_EXE): | $(BIN_DIR) $(GO_DEPS) $(VENDOR_DIR)
 	go build -o $(K8SNIFF_EXE)
 
 k8sniff: $(K8SNIFF_EXE)
 
 clean:
-	rm -rf $(BUILD_DIR)
+	rm -rf $(BUILD_DIR) $(DEP_SRC) $(VENDOR_DIR) $(GO_DEPS)
 
 k8sniff-clean:
 	rm -f $(K8SNIFF_EXE)

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,6 @@ IMAGE_TAG ?= $(VERSION)-$(BUILD_ID)
 FULL_TAG := $(REPO_TAG):$(IMAGE_TAG)
 TAG_FILE := $(BUILD_DIR)/container-full-tag
 
-GO_DEPS := \
-	$(GOSRC)/github.com/golang/glog \
-	$(GOSRC)/github.com/prometheus/client_golang/prometheus \
-	$(GOSRC)/github.com/platform9/cnxmd/pkg/cnxmd
-
-$(GO_DEPS): $(GOPATH_DIR)
-	go get $(subst $(GOSRC)/,,$@)
-
 $(DEP_SRC):
 	go get -u github.com/golang/dep/cmd/dep
 
@@ -46,13 +38,19 @@ local-k8sniff:
 local-k8sniff-dbg:
 	cd $(SRC_DIR)/cmd/k8sniff && go build -gcflags='-N -l' -o $${GOPATH}/bin/k8sniff-dbg
 
-$(K8SNIFF_EXE): | $(BIN_DIR) $(GO_DEPS) $(VENDOR_DIR)
+$(K8SNIFF_EXE): | $(BIN_DIR) $(VENDOR_DIR)
 	go build -o $(K8SNIFF_EXE)
+
+dep: $(DEP_EXE)
 
 k8sniff: $(K8SNIFF_EXE)
 
 clean:
-	rm -rf $(BUILD_DIR) $(DEP_SRC) $(VENDOR_DIR) $(TAG_FILE)
+	rm -rf $(BUILD_DIR) $(DEP_SRC) $(VENDOR_DIR)
+
+# dangerous: use with care. For testing
+clean-go-deps:
+	cd $(GOPATH)/src/github.com && ls | grep -v kubermatic | xargs rm -rf
 
 k8sniff-clean:
 	rm -f $(K8SNIFF_EXE)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ BUILD_SRC_DIR=$(BUILD_DIR)/src/github.com/kubermatic
 K8SNIFF_SRC_DIR=$(BUILD_SRC_DIR)/k8sniff
 K8SNIFF_EXE=$(BIN_DIR)/k8sniff
 
+GO_DEPS := \
+	$(GOSRC)/github.com/prometheus/client_golang \
+	$(GOSRC)/github.com/platform9/cnxmd \
+	$(GOSRC)/github.com/golang/glog
+
+$(GO_DEPS): $(GOPATH_DIR)
+	go get $(subst $(GOSRC)/,,$@)
+
 # Override with your own Docker registry tag(s)
 K8SNIFF_IMAGE_TAG ?= platform9systems/k8sniff
 K8SNIFF_DEVEL_IMAGE_TAG ?= platform9systems/k8sniff-devel
@@ -26,7 +34,7 @@ local-k8sniff:
 local-k8sniff-dbg:
 	cd $(SRC_DIR)/cmd/k8sniff && go build -gcflags='-N -l' -o $${GOPATH}/bin/k8sniff-dbg
 
-$(K8SNIFF_EXE): | $(BIN_DIR)
+$(K8SNIFF_EXE): | $(BIN_DIR) $(GO_DEPS)
 	go build -o $(K8SNIFF_EXE)
 
 k8sniff: $(K8SNIFF_EXE)

--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,7 @@ $(TAG_FILE): $(K8SNIFF_EXE)
 image: $(TAG_FILE)
 
 push: $(TAG_FILE)
-	docker push `cat $(TAG_FILE)` && docker rmi `cat $(TAG_FILE)`
+	(docker push $(FULL_TAG) || \
+		(echo -n $${DOCKER_PASSWORD} | docker login --password-stdin -u $${DOCKER_USERNAME} && \
+		docker push $(FULL_TAG) && docker logout))
+	docker rmi $(FULL_TAG)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BIN_DIR=$(BUILD_DIR)/bin
 BUILD_SRC_DIR=$(BUILD_DIR)/src/github.com/kubermatic
 K8SNIFF_SRC_DIR=$(BUILD_SRC_DIR)/k8sniff
 K8SNIFF_EXE=$(BIN_DIR)/k8sniff
+GOSRC=$(GOPATH_DIR)/src
 
 GO_DEPS := \
 	$(GOSRC)/github.com/prometheus/client_golang \

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ $(K8SNIFF_EXE): | $(BIN_DIR) $(GO_DEPS) $(VENDOR_DIR)
 k8sniff: $(K8SNIFF_EXE)
 
 clean:
-	rm -rf $(BUILD_DIR) $(DEP_SRC) $(VENDOR_DIR) $(GO_DEPS)
+	rm -rf $(BUILD_DIR) $(DEP_SRC) $(VENDOR_DIR) $(TAG_FILE)
 
 k8sniff-clean:
 	rm -f $(K8SNIFF_EXE)
@@ -64,4 +64,4 @@ $(TAG_FILE): $(K8SNIFF_EXE)
 image: $(TAG_FILE)
 
 push: $(TAG_FILE)
-	docker push `cat $(TAG_FILE)` && rm -f $(TAG_FILE)
+	docker push `cat $(TAG_FILE)` && docker rmi `cat $(TAG_FILE)`


### PR DESCRIPTION
The "push" target creates the binary, image, and pushes a versioned and tagged image to platform9/k8sniff on docker hub. It also creates a tag file that can be used as an artifact in a build pipeline.

TC build config: http://teamcity.platform9.horse:8111/admin/editBuild.html?id=buildType:Pf9project_DeccoBuilds_K8sniff